### PR TITLE
Fix NPE in slave registration and make default slave name prefix match the dynaslave UDF

### DIFF
--- a/src/main/java/com/netflix/jenkins/plugins/DynaSlave.java
+++ b/src/main/java/com/netflix/jenkins/plugins/DynaSlave.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.logging.Logger;
 
 /**
- * {@link Slave} created by ad-hoc local systems.
+ * {@link Slave}  created by ad-hoc local systems.
  * Initial concept heavily borrowed from the Swarm plugin
  */
 public class DynaSlave extends Slave {

--- a/src/main/java/com/netflix/jenkins/plugins/DynaSlavePlugin.java
+++ b/src/main/java/com/netflix/jenkins/plugins/DynaSlavePlugin.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
 public class DynaSlavePlugin extends Plugin {
     private static final Logger LOG = Logger.getLogger(DynaSlavePlugin.class.getName());
 
-    private String defaultPrefix = "ds";
+    private String defaultPrefix = "dynaslave";
     private String defaultLabels = "";
     private String defaultRemoteSlaveUser = "jenkins";
     private String defaultBaseLauncherCommand = "/apps/jenkins/tools/start-remote-dynaslave";

--- a/src/main/java/com/netflix/jenkins/plugins/DynaSlaveRetentionStrategy.java
+++ b/src/main/java/com/netflix/jenkins/plugins/DynaSlaveRetentionStrategy.java
@@ -24,7 +24,7 @@ import static java.util.logging.Level.WARNING;
 public class DynaSlaveRetentionStrategy extends RetentionStrategy<SlaveComputer> {
     private static final Logger LOGGER = Logger.getLogger(DynaSlaveRetentionStrategy.class.getName());
 
-    private AtomicInteger idleMinutes;
+    private AtomicInteger idleMinutes = new AtomicInteger(30);
     public AtomicBoolean disabled = new AtomicBoolean(Boolean.getBoolean(DynaSlaveRetentionStrategy.class.getName() + ".disabled"));
 
     @DataBoundConstructor


### PR DESCRIPTION
Testing on builds101:
1. Restart Jenkins with the new plugin, make sure existing slave registers and NPE is not thrown
2. Increase the jenkins_slave-upgradetest ASG size by 1 and make sure new instance registers with the master (this is where I had to change the default prefix).

Both tests passed.
